### PR TITLE
Added libXft-devel to Dockerfile

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos5
 
-RUN yum install -y make bzip2-devel bzip2-devel.i386 zlib-devel zlib-devel.i386 perl glibc-devel glibc-devel.i386 libX11-devel libX11-devel.i386 libXt-devel libXt-devel.i386 patch expat.i386 expat.x86_64
+RUN yum install -y make bzip2-devel bzip2-devel.i386 zlib-devel zlib-devel.i386 perl glibc-devel glibc-devel.i386 libX11-devel libX11-devel.i386 libXt-devel libXt-devel.i386 patch expat.i386 expat.x86_64 libXft-devel.i386 libXft-devel.x86_64
 
 RUN yum install -y wget
 RUN wget https://github.com/squeaky-pl/centos-devtools/releases/download/6.2/gcc-6.2.0-binutils-2.27-x86_64.tar.bz2 -O - | tar -C / -xj


### PR DESCRIPTION
An attempt to fix https://github.com/squeaky-pl/portable-pypy/issues/37
I wasn't able to finish the build process so I can't confirm that it works. Translating pypy with CPython is already slow, even slower under Docker, then it failed at the package step with:

```
Set RPATH of lib_pypy/_audioop_cffi.pypy-41.so to $ORIGIN/../lib
lib/libncurses.so libncurses.so.6
lib/libexpat.so libexpat.so.0
lib/libffi.so libffi.so.6
lib/libpanel.so libpanel.so.6
lib/libtinfo.so libtinfo.so.6
lib/libsqlite3.so libsqlite3.so.0
  File "./make_portable", line 128, in <module>
    main()
  File "./make_portable", line 113, in main
    symlink_deps('lib')
  File "./make_portable", line 54, in symlink_deps
    symlink(src, lnkname)
OSError: [Errno 17] File exists
```

This is just a minor nitpick as idle looks very ugly. 
