### PR TITLE
wget uses TLSv1 for communicate with sourceforge

### DIFF
--- a/build_deps
+++ b/build_deps
@@ -27,7 +27,7 @@ make -j4
 make install
 cd -
 
-wget http://tukaani.org/xz/xz-5.2.3.tar.gz -O - | tar xz
+wget --secure-protocol=TLSv1 https://tukaani.org/xz/xz-5.2.3.tar.gz -O - | tar xz
 cd xz-5.2.3
 ./configure --prefix=/opt/prefix
 make -j4


### PR DESCRIPTION
wget sometimes tries to use deprecated protocols. This closes issue #57.