### PR TITLE
Clean __pycache__ when packaging before tar.

### DIFF
--- a/package
+++ b/package
@@ -62,6 +62,10 @@ cp /src/virtualenv-pypy pypy-pack/bin/virtualenv-pypy
 
 rm -rf $NAME
 mv pypy-pack $NAME
+
+# clean __pycache__
+find ./{NAME} -name "__pycache__" | xargs rm -rf >/dev/null 2>&1
+
 rm -f ${NAME}.tar.bz2
 tar -cjf ${NAME}.tar.bz2 $NAME
 


### PR DESCRIPTION
Clean `__pycache__` when packaging before tar.