### PR TITLE
Note that all downloads are not on BitBucket any longer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Latest Python 2.7 release
     sha256: a4f301e7629aafe4691ed1c3e9a39cf2158d86524f6ce584e5b850303e77ad81
 
 
-All downloads can be found `here <https://bitbucket.org/squeaky/portable-pypy/downloads>`_
+All older downloads (pre 7.2) can be found `here <https://bitbucket.org/squeaky/portable-pypy/downloads>`_
 
 Using virtualenv
 ================


### PR DESCRIPTION
See https://github.com/squeaky-pl/portable-pypy/issues/94#issuecomment-543495847